### PR TITLE
fix : #12

### DIFF
--- a/src/issueRow.js
+++ b/src/issueRow.js
@@ -12,7 +12,8 @@ export class IssueRow extends React.Component {
           <div>
             <a
               href={issue.url}
-              target="blank"
+              target="_blank"
+              rel="noopener noreferrer"
               style={{ display: "inline-block", minWidth: `${width}px` }}
             >
               #{issue.number}

--- a/src/repoRow.js
+++ b/src/repoRow.js
@@ -19,7 +19,7 @@ export class RepoRow extends React.Component {
             >
               {expanded ? "\u2212" : "+"}
             </button>
-            <a href={repo.url} target="blank">
+            <a href={repo.url} target="_blank" rel="noopener noreferrer">
               {repo.title}
             </a>
           </td>


### PR DESCRIPTION
fix https://github.com/BrianLitwin/GoodFirstIssue/issues/12 : Clicking on link switches tabs sometimes, instead of linking to repo url (in new tab)

added rel=”noopener noreferrer” - refer to https://medium.com/@ali.dev/how-to-fix-target-blank-a-security-and-performance-issue-in-web-pages-2118eba1ce2f

